### PR TITLE
⚡ perf: simulate permutations, dense signature matrix

### DIFF
--- a/locality_sensitive_hashing/lsh.py
+++ b/locality_sensitive_hashing/lsh.py
@@ -343,7 +343,7 @@ def min_hash(signature_set: DenseSignatureSet) -> MinHashMatrix:
     else:
         prime = next_prime(total_shingles)
 
-    def _hash(x: npt.NDArray[np.intp], p: int, a: int, b: int) -> IntArray:
+    def universal_hash(x: npt.NDArray[np.intp], p: int, a: int, b: int) -> IntArray:
         """
         Universal Hash Function
 
@@ -365,7 +365,9 @@ def min_hash(signature_set: DenseSignatureSet) -> MinHashMatrix:
 
     for i in range(number_of_permutations):
         for j, rows in enumerate(signature_set):
-            min_hash_signatures[i, j] = np.min(_hash(rows, prime, *coefficients[i]))
+            min_hash_signatures[i, j] = np.min(
+                universal_hash(rows, prime, *coefficients[i])
+            )
 
     return min_hash_signatures
 

--- a/locality_sensitive_hashing/lsh.py
+++ b/locality_sensitive_hashing/lsh.py
@@ -315,7 +315,7 @@ def min_hash(signature_set: DenseSignatureSet) -> MinHashMatrix:
             The number of permutations to simulate.
 
     Arguments:
-        DenseSignatureSet
+        signature_set: DenseSignatureSet
             A list of length N, where each element i is an array of indices of shingles that appear
             in document i.
 

--- a/locality_sensitive_hashing/lsh.py
+++ b/locality_sensitive_hashing/lsh.py
@@ -32,7 +32,7 @@ KShingles = list[set[str]]
 Candidates = set[tuple[int, int]]
 IntArray = npt.NDArray[np.int64]
 MinHashMatrix = IntArray
-SignatureSet = IntArray
+SignatureSet = npt.NDArray[np.bool_]
 LSHSimilarityMatrix = npt.NDArray[np.float64]
 
 
@@ -205,7 +205,7 @@ def signature_set(k_shingles: KShingles) -> SignatureSet:
         unique_shingles.update(shingles)
 
     signature_set: SignatureSet = np.zeros(
-        shape=[len(unique_shingles), len(k_shingles)], dtype=np.int64
+        shape=[len(unique_shingles), len(k_shingles)], dtype=np.bool_
     )
 
     # Sets have no ordering guarantee, so we need to sort them

--- a/locality_sensitive_hashing/lsh.py
+++ b/locality_sensitive_hashing/lsh.py
@@ -28,11 +28,12 @@ class Parameters(TypedDict):
     t: float
 
 
-KShingles = list[set[str]]
+KShingles = list[npt.NDArray[np.str_]]
 Candidates = set[tuple[int, int]]
 IntArray = npt.NDArray[np.int64]
 MinHashMatrix = IntArray
 SignatureSet = npt.NDArray[np.bool_]
+DenseSignatureSet = dict[int, npt.NDArray[np.intp]]
 LSHSimilarityMatrix = npt.NDArray[np.float64]
 
 
@@ -164,13 +165,13 @@ def k_shingles() -> KShingles:
         for i in range(len(doc) - k + 1):
             shingles.add(doc[i : i + k])
 
-        docs_k_shingles.append(shingles)
+        docs_k_shingles.append(np.array(list(shingles)))
     return docs_k_shingles
 
 
 # METHOD FOR TASK 2
 # Creates a signatures set of the documents from the k-shingles list
-def signature_set(k_shingles: KShingles) -> SignatureSet:
+def signature_set(k_shingles: KShingles) -> DenseSignatureSet:
     """
     Arguments:
         k_shingles: KShingles
@@ -205,25 +206,22 @@ def signature_set(k_shingles: KShingles) -> SignatureSet:
         unique_shingles.update(shingles)
 
     print("Total shingles:", len(unique_shingles))
-    signature_set: SignatureSet = np.zeros(
-        shape=[len(unique_shingles), len(k_shingles)], dtype=np.bool_
-    )
+    dense_signature_set: dict[int, npt.NDArray[np.intp]] = dict()
 
     # Sets have no ordering guarantee, so we need to sort them
     # for the signature set to be consistent and reproducable.
-    ordered_shingles = sorted(list(unique_shingles))
+    ordered_shingles = np.sort(np.array(list(unique_shingles)))
+    for i, document in enumerate(k_shingles):
+        mask = np.isin(ordered_shingles, document, assume_unique=True)
+        indices = np.nonzero(mask)[0]
+        dense_signature_set[i] = indices
 
-    for i, shingle in enumerate(ordered_shingles):
-        for j, document in enumerate(k_shingles):
-            if shingle in document:
-                signature_set[i, j] = 1
-
-    return signature_set
+    return dense_signature_set
 
 
 # METHOD FOR TASK 3
 # Creates the minHash signatures after simulation of permutations
-def min_hash(docs_signature_sets: SignatureSet) -> MinHashMatrix:
+def min_hash(docs_signature_sets: DenseSignatureSet) -> MinHashMatrix:
     """
     Takes a matrix of size M x N, where M is the total number of unique shingles in all documents,
     and N is the total number of documents. Each row i is the signature set of a given shingle, and
@@ -249,16 +247,21 @@ def min_hash(docs_signature_sets: SignatureSet) -> MinHashMatrix:
     number_of_permutations = parameters_dictionary["permutations"]
 
     min_hash_signatures: MinHashMatrix = np.empty(
-        shape=(number_of_permutations, docs_signature_sets.shape[1]), dtype=np.int64
+        shape=(number_of_permutations, len(document_list)), dtype=np.int64
     )
 
     rng = np.random.default_rng(seed=42)
     for i in range(number_of_permutations):
-        permutation = rng.permutation(docs_signature_sets)
-        # Index of the first non-zero element in the permutation
-        signature: MinHashMatrix = (permutation != 0).argmax(axis=0)
-        min_hash_signatures[i, :] = signature
+        for j, signatures in docs_signature_sets.items():
+            permutation: np.intp = rng.permutation(signatures)[0]
+            min_hash_signatures[i, j] = permutation
 
+        # permutation = rng.permutation(docs_signature_sets)
+        # # Index of the first non-zero element in the permutation
+        # signature: MinHashMatrix = (permutation != 0).argmax(axis=0)
+        # min_hash_signatures[i, :] = signature
+
+    print(min_hash_signatures)
     return min_hash_signatures
 
 

--- a/locality_sensitive_hashing/lsh.py
+++ b/locality_sensitive_hashing/lsh.py
@@ -204,6 +204,7 @@ def signature_set(k_shingles: KShingles) -> SignatureSet:
     for shingles in k_shingles:
         unique_shingles.update(shingles)
 
+    print("Total shingles:", len(unique_shingles))
     signature_set: SignatureSet = np.zeros(
         shape=[len(unique_shingles), len(k_shingles)], dtype=np.bool_
     )
@@ -253,9 +254,16 @@ def min_hash(docs_signature_sets: SignatureSet) -> MinHashMatrix:
 
     rng = np.random.default_rng(seed=42)
     for i in range(number_of_permutations):
+        start = time.time()
         permutation = rng.permutation(docs_signature_sets)
+        permutation_time = time.time()
         signature: MinHashMatrix = np.argmax(permutation, axis=0)
+        signature_time = time.time()
         min_hash_signatures[i, :] = signature
+        permutation_complete_time = time.time()
+        print(
+            f"Permutation {i} took:\n{permutation_time - start} permutation\n{signature_time - permutation_time} signature\n{permutation_complete_time - start} total\n"
+        )
 
     return min_hash_signatures
 

--- a/locality_sensitive_hashing/lsh.py
+++ b/locality_sensitive_hashing/lsh.py
@@ -180,9 +180,6 @@ def miller_rabin_test(n: int, k: int = 100) -> bool:
             An odd integer > 2 to be tested for primality
         k: int
             The number of rounds of testing to perform
-        seed: int
-            The seed for the random number generator
-
     Returns:
         bool
             True if n is _probably_ prime, False if n is _definitely_ composite
@@ -218,6 +215,8 @@ def next_prime(n: int, seed=42) -> int:
     Arguments:
         n: int
             An odd integer > 2
+        seed: int
+            The seed to use for the random number generator
     """
     random.seed(seed)
 
@@ -239,7 +238,6 @@ def signature_set(k_shingles: KShingles) -> DenseSignatureSet:
     For a given list of k-shingles per document, creates a dense signature set of the documents.
     Since a boolean matrix representation is [typically sparse](http://infolab.stanford.edu/~ullman/mining/2009/similarity1.pdf),
     we will use a dense representation instead.
-
 
     Arguments:
         k_shingles: KShingles


### PR DESCRIPTION
### Changes
- Simulate permutations by generating `k` unique hash functions of the form

$$
h_i(x)=(a \cdot x + b)\mod(p)
$$

Where $a, b \in \mathbb{Z}^{+} < N$ and $p > N$ is the smallest prime number greater than $N$, where $N$ is the total number of unique shingles in all documents.

The prime number is found using the [Miller-Rabin Primality Test](https://en.wikipedia.org/wiki/Miller–Rabin_primality_test)

- Represent the signature set as a matrix of indices of shingles that exist in a given document.
  - i.e.
  The set of all shingles is the array $K$ with length $N$
  The signature set is a list, $S$, of size $I$, where $I$ is the total number of documents. The element $S_{i,j}$ is the index of a shingle in $K$ that appears in document $i$.
http://infolab.stanford.edu/~ullman/mining/2009/similarity1.pdf

Results in a _significant_ performance improvement. 

Compared to the existing version, with standard parameters:
| Commit | Signatures Representation | MinHash Signature Matrix | Total |
|--------|--------|--------|--------|
| 24d4e5a | $5.27$ seconds | $28.0$ seconds | $34.1$ seconds |
| 70fc59d | $1.85$ seconds | $0.20$ seconds | $2.92$ seconds |
| improvement | $3.42$ seconds | $27.8$ seconds | $31.18$ seconds |
